### PR TITLE
Require node v4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/Farof/heroprotocoljs/issues"
   },
-  "homepage": "https://github.com/Farof/heroprotocoljs"
+  "homepage": "https://github.com/Farof/heroprotocoljs",
+  "engines" : {
+    "node" : ">=4.0.0"
+  }
 }


### PR DESCRIPTION
ES6 features require node > v4.0.

We do not accidentally want someone to think they could use the library on an old version.
