### PR TITLE
Add convenience parse-only functions for lower-level integration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,3 +121,39 @@ exports.get = function (archiveFile, archive) {
 
   return data;
 };
+
+/**
+ * parses a basic MPQ header
+ * @function
+ * @param {buffer} buffer - Header content from MPQ archive
+ * @returns {object} Header information from file
+ */
+exports.parseHeader = function (buffer) {
+  return parseStrings(protocol29406.decodeReplayHeader(buffer));
+};
+
+/**
+ * parses a buffer based on a given build
+ * @function
+ * @param {buffer} buffer - Binary file contents from MPQ archive
+ * @param {string} build - Build in which to parse the contents
+ * @param {string} filename - Name of the file to assist in parsing
+ * @returns {object} File contents
+ */
+exports.parseFile = function (buffer, build, filename) {
+  var data;
+  try {
+    var protocol = require(`./lib/protocol${build}`);
+  } catch (err) {
+    return undefined;
+  }
+  if ([DETAILS, INITDATA, ATTRIBUTES_EVENTS].indexOf(filename) > -1) {
+    data = parseStrings(protocol[decoderMap[filename]](buffer));
+  } else if ([GAME_EVENTS, MESSAGE_EVENTS, TRACKER_EVENTS].indexOf(filename) > -1) {
+    data = [];
+    for (let event of protocol[decoderMap[filename]](buffer)) {
+      data.push(parseStrings(event));
+    }
+  }
+  return data;
+};


### PR DESCRIPTION
- `.parseHeader(buffer)` - parses MPQ Header
- `.parseFile(buffer, build, filename)` - parses file content

These functions permit parsing of binary content for applications which
may have already extracted data from the archive.

Closes #29
