### PR TITLE
Cross-platform compatibility for port.js

### DIFF
--- a/src/port.js
+++ b/src/port.js
@@ -172,7 +172,7 @@ const types = {
 };
 
 const tokens = {
-  newline: '\r\n',
+  newline: '\n',
   indent: '  ',
   typeinfosStart: 'typeinfos = [',
   typeinfosEnd: ']',


### PR DESCRIPTION
ALL OSes respect `\n` as their new line character, however, if the line still
contains a `\r` (Windows), it will be caught on Line 216 with the `trim()`.
